### PR TITLE
Use ironcore_alloy batch_decrypt functions

### DIFF
--- a/server/src/notes.rs
+++ b/server/src/notes.rs
@@ -247,7 +247,7 @@ pub async fn chat(
                 ai_sdk,
                 decrypted_note
                     .result
-                    .get(0)
+                    .first()
                     .cloned()
                     .unwrap_or_else(Note::default),
                 input,


### PR DESCRIPTION
This is a pretty line-intensive change as it involves keeping 3 hashmaps in sync (std-encrypted data, det-encrypted data, unencrypted data) throughout. I was unsure what we were planning to do for partial failures, so for now I just return the successes and log a warning for each failure.

Also includes clippy suggestions